### PR TITLE
LIBFCREPO-27. Build profiles for noauth and ispn-remote.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,20 @@
       </build>
     </profile>
 
+    <profile>
+      <id>noauth</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-war-plugin</artifactId>
+            <configuration>
+              <webXml>${project.basedir}/src/noauth/web.xml</webXml>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    
   </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,22 @@
       </build>
     </profile>
     
+    <profile>
+      <id>ispn-remote</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.infinispan</groupId>
+          <artifactId>infinispan-cachestore-remote</artifactId>
+          <version>${infinispan.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.infinispan</groupId>
+          <artifactId>infinispan-client-hotrod</artifactId>
+          <version>${infinispan.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    
   </profiles>
 
 </project>

--- a/src/noauth/web.xml
+++ b/src/noauth/web.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	version="3.0">
+
+	<display-name>Fedora 4</display-name>
+
+	<context-param>
+		<param-name>contextConfigLocation</param-name>
+		<param-value>WEB-INF/classes/spring/auth-master.xml</param-value>
+	</context-param>
+
+	<listener>
+		<listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+	</listener>
+
+  <servlet>
+    <servlet-name>jersey-servlet</servlet-name>
+    <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+
+    <init-param>
+      <param-name>javax.ws.rs.Application</param-name>
+      <param-value>org.fcrepo.http.commons.FedoraApplication</param-value>
+    </init-param>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+	<servlet-mapping>
+		<servlet-name>jersey-servlet</servlet-name>
+		<url-pattern>/rest/*</url-pattern>
+	</servlet-mapping>
+
+</web-app>


### PR DESCRIPTION
-  Profile "noauth" includes web.xml without servlet authentication. Should be stackable with any of the other profiles (webac, rbacl, xacml, audit).
-  Profile "ispn-remote" includes infinispan-cachestore-remote and infinispan-client-hotrod JARs.

https://issues.umd.edu/browse/LIBFCREPO-27
